### PR TITLE
Patch for Poetry 2.x compatibility

### DIFF
--- a/src/managers/docker.py
+++ b/src/managers/docker.py
@@ -31,8 +31,19 @@ class DockerManager:
         cmd = [
             "pip install -U pip",
             f"pip install poetry=={self.poetry_version}",
-            "poetry export -f requirements.txt -o requirements-frozen.txt --without-hashes --dev",
         ]
+
+        # Poetry 2.x requires the export plugin to be installed separately
+        poetry_major_version = int(self.poetry_version.split(".")[0])
+        if poetry_major_version >= 2:
+            cmd.append("pip install poetry-plugin-export")
+            # Poetry 2.x uses --with dev instead of --dev
+            export_cmd = "poetry export -f requirements.txt -o requirements-frozen.txt --without-hashes --with dev"
+        else:
+            # Poetry 1.x uses --dev
+            export_cmd = "poetry export -f requirements.txt -o requirements-frozen.txt --without-hashes --dev"
+
+        cmd.append(export_cmd)
         self.bash_cmd = " && ".join(cmd)
 
     def run(self, run_cmd=None, bash_cmd=None):

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -3,18 +3,27 @@ from unittest.mock import patch
 from src.managers.docker import DockerManager
 
 
-@patch("subprocess.run")
-def test_docker_manager_instance(mock_subprocess_run):
+def test_docker_manager_instance_basic():
+    """Test basic DockerManager instance attributes"""
     docker_manager = DockerManager(
         "python",
-        "3.9.7",
+        "2.0.0",
         "repo_dir",
     )
 
     assert docker_manager.image == "python"
-    assert docker_manager.poetry_version == "3.9.7"
+    assert docker_manager.poetry_version == "2.0.0"
     assert docker_manager.repo_dir == "repo_dir"
     assert docker_manager.docker_run_name == "poetry-export"
+
+
+def test_docker_manager_run_command():
+    """Test docker run command generation"""
+    docker_manager = DockerManager(
+        "python",
+        "2.0.0",
+        "repo_dir",
+    )
 
     docker_manager.generate_run_command()
     assert (
@@ -22,10 +31,44 @@ def test_docker_manager_instance(mock_subprocess_run):
         == "docker run --name poetry-export -it --rm --volume repo_dir:/app -w /app python bash -c"
     )
 
+
+def test_docker_manager_bash_command_poetry_1x():
+    """Test bash command generation for Poetry 1.x"""
+    docker_manager = DockerManager(
+        "python",
+        "1.8.0",
+        "repo_dir",
+    )
+
     docker_manager.generate_bash_command()
     assert (
         docker_manager.bash_cmd
-        == "pip install -U pip && pip install poetry==3.9.7 && poetry export -f requirements.txt -o requirements-frozen.txt --without-hashes --dev"  # noqa: E501
+        == "pip install -U pip && pip install poetry==1.8.0 && poetry export -f requirements.txt -o requirements-frozen.txt --without-hashes --dev"  # noqa: E501
+    )
+
+
+def test_docker_manager_bash_command_poetry_2x():
+    """Test bash command generation for Poetry 2.x"""
+    docker_manager = DockerManager(
+        "python",
+        "2.0.0",
+        "repo_dir",
+    )
+
+    docker_manager.generate_bash_command()
+    assert (
+        docker_manager.bash_cmd
+        == "pip install -U pip && pip install poetry==2.0.0 && pip install poetry-plugin-export && poetry export -f requirements.txt -o requirements-frozen.txt --without-hashes --with dev"  # noqa: E501
+    )
+
+
+@patch("subprocess.run")
+def test_docker_manager_run(mock_subprocess_run):
+    """Test docker manager run method"""
+    docker_manager = DockerManager(
+        "python",
+        "2.0.0",
+        "repo_dir",
     )
 
     docker_manager.run()


### PR DESCRIPTION
This pull request updates the `DockerManager` to support both Poetry 1.x and 2.x versions when generating bash commands, and adds comprehensive tests to ensure correct behavior for both versions. The changes ensure compatibility with Poetry 2.x, which requires an additional export plugin and different command-line arguments.

**Poetry version compatibility improvements:**

* Updated `generate_bash_command` in `src/managers/docker.py` to detect the Poetry major version and adjust the export command accordingly: installs `poetry-plugin-export` and uses `--with dev` for Poetry 2.x, while retaining `--dev` for Poetry 1.x.

**Test enhancements:**

* Added new tests in `tests/test_docker.py` to verify correct bash command generation for both Poetry 1.x and 2.x, and to check basic attributes and run command generation of `DockerManager`.
* Added a test for the `run` method of `DockerManager`, using mocking to avoid actual subprocess execution.